### PR TITLE
Update IbcAlpha/IBC to 3.8.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /root
 RUN wget -q --progress=bar:force:noscroll --show-progress https://download2.interactivebrokers.com/installers/ibgateway/latest-standalone/ibgateway-latest-standalone-linux-x64.sh -O install-ibgateway.sh
 RUN chmod a+x install-ibgateway.sh
 
-RUN wget -q --progress=bar:force:noscroll --show-progress https://github.com/IbcAlpha/IBC/releases/download/3.8.1/IBCLinux-3.8.1.zip -O ibc.zip
+RUN wget -q --progress=bar:force:noscroll --show-progress https://github.com/IbcAlpha/IBC/releases/download/3.8.2/IBCLinux-3.8.2.zip -O ibc.zip
 RUN unzip ibc.zip -d /opt/ibc
 RUN chmod a+x /opt/ibc/*.sh /opt/ibc/*/*.sh
 


### PR DESCRIPTION
In addition to a few bug fixes, the 3.8.2 upgrade supports 2FA authentication by accept a pop-up from the mobile app: https://github.com/IbcAlpha/IBC/releases/tag/3.8.2

Also, hello! 👋 