### PR TITLE
Fix for version 980

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /root
 RUN wget -q --progress=bar:force:noscroll --show-progress https://download2.interactivebrokers.com/installers/ibgateway/latest-standalone/ibgateway-latest-standalone-linux-x64.sh -O install-ibgateway.sh
 RUN chmod a+x install-ibgateway.sh
 
-RUN wget -q --progress=bar:force:noscroll --show-progress https://github.com/IbcAlpha/IBC/releases/download/3.8.2/IBCLinux-3.8.2.zip -O ibc.zip
+RUN wget -q --progress=bar:force:noscroll --show-progress https://github.com/IbcAlpha/IBC/releases/download/3.8.4-beta.2/IBCLinux-3.8.4-beta.2.zip -O ibc.zip
 RUN unzip ibc.zip -d /opt/ibc
 RUN chmod a+x /opt/ibc/*.sh /opt/ibc/*/*.sh
 
@@ -25,7 +25,7 @@ RUN apt-get install -y x11vnc xvfb socat
 WORKDIR /root
 
 COPY --from=builder /root/install-ibgateway.sh install-ibgateway.sh
-RUN yes n | ./install-ibgateway.sh
+RUN yes "" | ./install-ibgateway.sh
 
 RUN mkdir .vnc
 RUN x11vnc -storepasswd 1358 .vnc/passwd


### PR DESCRIPTION
Version 980 has a different window title, login interface and different installer prompts.

Not tested with older versions of gateway.